### PR TITLE
Fixes criticmarkup highlighting not appearing in some pandoc syntax groups

### DIFF
--- a/autoload/criticmarkup.vim
+++ b/autoload/criticmarkup.vim
@@ -4,14 +4,14 @@ function! criticmarkup#Init()
 endfunction
 
 function! criticmarkup#InjectHighlighting()
-    syn region criticAddition matchgroup=criticAdd start=/{++/ end=/++}/ containedin=pandocDefinitionBlock,pandocYAMLHeader,yamlBlock,yamlHeader,yamlPlainScalar,yamlFlowString concealends
-    syn region criticDeletion matchgroup=criticDel start=/{--/ end=/--}/ containedin=pandocDefinitionBlock,pandocYAMLHeader,yamlBlock,yamlHeader,yamlPlainScalar,yamlFlowString concealends
-    syn region criticSubstitutionDeletion start=/{\~\~/ end=/.\(\~>\)\@=/ containedin=pandocDefinitionBlock,pandocYAMLHeader,yamlBlock,yamlHeader,yamlPlainScalar,yamlFlowString keepend
-    syn region criticSubstitutionAddition start=/\~>/ end=/\~\~}/ containedin=pandocDefinitionBlock,pandocYAMLHeader,yamlBlock,yamlHeader,yamlPlainScalar,yamlFlowString keepend
+    syn region criticAddition matchgroup=criticAdd start=/{++/ end=/++}/ containedin=pandocAtxHeader,pandocBlockQuote,pandocCodeBlock,pandocFootnoteBlock,pandocListItem,pandocUListItem,pandocDefinitionBlock,pandocYAMLHeader,yamlBlock,yamlHeader,yamlPlainScalar,yamlFlowString concealends
+    syn region criticDeletion matchgroup=criticDel start=/{--/ end=/--}/ containedin=pandocAtxHeader,pandocBlockQuote,pandocCodeBlock,pandocFootnoteBlock,pandocListItem,pandocUListItem,pandocDefinitionBlock,pandocYAMLHeader,yamlBlock,yamlHeader,yamlPlainScalar,yamlFlowString concealends
+    syn region criticSubstitutionDeletion start=/{\~\~/ end=/.\(\~>\)\@=/ containedin=pandocAtxHeader,pandocBlockQuote,pandocCodeBlock,pandocFootnoteBlock,pandocListItem,pandocUListItem,pandocDefinitionBlock,pandocYAMLHeader,yamlBlock,yamlHeader,yamlPlainScalar,yamlFlowString keepend
+    syn region criticSubstitutionAddition start=/\~>/ end=/\~\~}/ containedin=pandocAtxHeader,pandocBlockQuote,pandocCodeBlock,pandocFootnoteBlock,pandocListItem,pandocUListItem,pandocDefinitionBlock,pandocYAMLHeader,yamlBlock,yamlHeader,yamlPlainScalar,yamlFlowString keepend
     syn match criticSubstitutionDeletionMark /{\~\~/ contained containedin=criticSubstitutionDeletion conceal
     syn match criticSubstitutionAdditionMark /\~\~}/ contained containedin=criticSubstitutionAddition conceal
-    syn region criticComment matchgroup=criticMeta start=/{>>/ end=/<<}/ containedin=pandocDefinitionBlock,pandocYAMLHeader,yamlBlock,yamlHeader,yamlPlainScalar,yamlFlowString concealends
-    syn region criticHighlight matchgroup=criticHighlighter start=/{==/ end=/==}/ containedin=pandocDefinitionBlock,pandocYAMLHeader,yamlBlock,yamlHeader,yamlPlainScalar,yamlFlowString concealends
+    syn region criticComment matchgroup=criticMeta start=/{>>/ end=/<<}/ containedin=pandocAtxHeader,pandocBlockQuote,pandocCodeBlock,pandocFootnoteBlock,pandocListItem,pandocUListItem,pandocDefinitionBlock,pandocYAMLHeader,yamlBlock,yamlHeader,yamlPlainScalar,yamlFlowString concealends
+    syn region criticHighlight matchgroup=criticHighlighter start=/{==/ end=/==}/ containedin=pandocAtxHeader,pandocBlockQuote,pandocCodeBlock,pandocFootnoteBlock,pandocListItem,pandocUListItem,pandocDefinitionBlock,pandocYAMLHeader,yamlBlock,yamlHeader,yamlPlainScalar,yamlFlowString concealends
 
     hi criticAdd guibg=#00ff00 guifg=#101010 ctermbg=46 ctermfg=16
     hi criticDel guibg=#ff0000 guifg=#ffffff ctermbg=196 ctermfg=231


### PR DESCRIPTION
This pull requests fixes #12 

Some pandoc syntax groups were not being included in `containedin`, which meant that criticmarkup syntax highlighting didn't work in some areas in a pandoc document (e.g, headers, numbered and unsorted lists, etc.)

The pull request adds the following pandoc syntax groups:

- `pandocAtxHeader`
- `pandocCodeBlock`
- `pandocListItem`
- `pandocUListItem`
- `pandocBlockQuote`
- `pandocFootnoteBlock`

**Testing**

I used the snippet that demonstrated the problem in the issue:

```markdown
{>> highlighting comments works in beginning of line <<}
And it worked within a {>> line <<}.
  It does work in a line indented with {>> two spaces <<}
    But it doesn't work {>> in an indented line with 4 spaces <<}
  - and It does not work in a line in a list {>> like this <<}
```

And this is the result after the fix:

![screenshot 2017-08-12 20 35 32](https://user-images.githubusercontent.com/3160968/29245920-5d1d74a0-7f9e-11e7-9278-4490c61ca7f3.png)

I also tested it on a markdown file that contains all the added syntax groups.

Hopefully this can be merged soon :) Let me know if there are any issues.